### PR TITLE
Generalizing uuid to apply for any identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ You'd be running it as follows:
 touchstone_compare uperf elasticsearch ripsaw -url marquez.perf.lab.eng.rdu2.redhat.com marquez.perf.lab.eng.rdu2.redhat.com  -u 6c5d0257-57e4-54f0-9c98-e149af8b4a5c 70cbb0eb-8bb6-58e3-b92a-cb802a74bb52
 ```
 
+### Comparing on a specific identifier
+
+You can also now compare against identifiers other than the `uuid` key, so for
+example if you'd like to compare using the key `cluster_name` you can do so by
+using the `-id` argument and run as follows:
+
+```
+touchstone_compare uperf elasticsearch ripsaw -url marquez.perf.lab.eng.rdu2.redhat.com -u cnvcluster minikube -id cluster_name
+```
+
+Note: If the identifier is same for 2 or more uuids, then all of the results
+will be taken into consideration while computing aggregations, so please use
+with caution.
+
 
 ## Contributing
 

--- a/src/touchstone/utils/lib.py
+++ b/src/touchstone/utils/lib.py
@@ -69,7 +69,7 @@ def mergedicts(dict1, dict2):
             yield (k, dict2[k])
 
 
-def compare_dict(d1, aggs, _message, buckets, uuids, _header, max_level,
+def compare_dict(d1, identifier, aggs, _message, buckets, uuids, _header, max_level,
                  csv=False, level=0):
     for key in d1:
         if type(d1[key]) is dict and key not in aggs and level < max_level - 1:
@@ -80,7 +80,7 @@ def compare_dict(d1, aggs, _message, buckets, uuids, _header, max_level,
                     new_message = _message + " {:20} |".format(key)
                 else:
                     new_message = _message + "{}, ".format(key)
-                compare_dict(d1[key], aggs, new_message, buckets,
+                compare_dict(d1[key], identifier, aggs, new_message, buckets,
                              uuids, _header, max_level, csv, new_level)
             else:
                 # this means it's a bucket name
@@ -88,7 +88,7 @@ def compare_dict(d1, aggs, _message, buckets, uuids, _header, max_level,
                     new_header = _header + " {:20} |".format(key)
                 else:
                     new_header = _header + "{}, ".format(key)
-                compare_dict(d1[key], aggs, _message, buckets,
+                compare_dict(d1[key], identifier, aggs, _message, buckets,
                              uuids, new_header, max_level, csv, new_level)
         else:
             bool_header = True
@@ -96,7 +96,7 @@ def compare_dict(d1, aggs, _message, buckets, uuids, _header, max_level,
                 _output = _header + '\n'
                 final_message = _message + " {:20} |".format(key)
                 _output = _output + final_message + '\n'
-                _compare_header = "{:30} |".format("key")
+                _compare_header = "{:30} |".format(identifier)
                 for uuid in uuids:
                     _compare_header = \
                         _compare_header + " {:20} |".format(uuid[:16])


### PR DESCRIPTION
Generalizing the identifier to apply for fields other than uuid.
This would allow for comparing results based on say cluster_name,
or any other keys.

Defaults identifier to uuid to avoid breaking other entities that
depend on touchstone.