### PR TITLE
Exclude filter to avoid computing zeros in uperf aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ As a contributor, more often than not you'll be adding code to benchmarks dir.
 
 ### Benchmarks
 
-To add a new benchmark, you'll create your the class and define three member function which will need to put together the following 4 types of keys:
+To add a new benchmark, you'll create your the class and define three member function which will need to put together the following 5 types of keys:
 
 1. Filter: To only take the particular entry into consideration if it passes filter
 2. Bucket: To facilitate apple to apple comparison, touchstone will put records into buckets
 3. Aggregation: Apply aggregation and the type on the keys
 4. Compare: Compare the keys that help characterize the SUT/benchmark run
 5. Collate: Collates the keys after applying filters, buckets and aggregations.
+5. Exclude: Excludes entries which passes this filter.
 
 The member functions are:
 
@@ -61,6 +62,9 @@ The member functions are:
     b. 'buckets': this is a list of all the various keys we'll need to look at while bucketing to ensure we do an apple to apple comparison. one example for uperf is ['protocol.keyword', 'message_size', 'num_threads']
 
     c. 'aggregations': aggregations is a dictionary of keys to do aggregations with value being a list of type of aggregations, note an aggregation can also be a dictionary. one example for uperf is {'norm_byte': ['max', 'avg', {'percentiles': {'percents': [50]}}]}
+
+
+    d. 'exclude': excludes documents from the query that meet these conditions. For uperf we exclude documents with zero norm_ops metrics with {'norm_ops': 0}
 
 2. emit_compare_map(): This should emit a dictionary where key is the index and the value is a list of keys to compare
 
@@ -81,6 +85,9 @@ And you'll need to create the above for all the indices in the database choice, 
               'filter': {
                 'test_type.keyword': 'stream'
               },
+              'exclude': {
+                'norm_ops': 0
+              },
               'buckets': ['protocol.keyword',
                 'message_size', 'num_threads'
               ],
@@ -93,6 +100,9 @@ And you'll need to create the above for all the indices in the database choice, 
             }, {
               'filter': {
                 'test_type.keyword': 'rr'
+              },
+              'exclude': {
+                'norm_ops': 0
               },
               'buckets': ['protocol.keyword',
                 'message_size', 'num_threads'

--- a/src/touchstone/benchmarks/uperf.py
+++ b/src/touchstone/benchmarks/uperf.py
@@ -41,6 +41,9 @@ class Uperf(BenchmarkBaseClass):
                             'filter': {
                                 'test_type.keyword': 'stream'
                             },
+                            'exclude': {
+                                'norm_ops': 0
+                            },
                             'buckets': ['protocol.keyword', 'message_size',
                                         'num_threads'],
                             'aggregations': {
@@ -56,6 +59,9 @@ class Uperf(BenchmarkBaseClass):
                         }, {
                             'filter': {
                                 'test_type.keyword': 'rr'
+                            },
+                            'exclude': {
+                                'norm_ops': 0
                             },
                             'buckets': ['protocol.keyword', 'message_size',
                                         'num_threads'],

--- a/src/touchstone/databases/elasticsearch.py
+++ b/src/touchstone/databases/elasticsearch.py
@@ -79,7 +79,7 @@ class Elasticsearch(DatabaseBaseClass):
                    index=str(index)).query("match", **{"uuid.keyword":str(uuid)})
         for key, value in filters.items():
             s = s.filter("term", **{str(key): str(value)})
-        if 'exclude' in search_map: 
+        if 'exclude' in search_map:
             for key, value in search_map['exclude'].items():
                 s = s.exclude('match', **{key: value})
         _logger.debug("Building query")

--- a/src/touchstone/databases/elasticsearch.py
+++ b/src/touchstone/databases/elasticsearch.py
@@ -79,6 +79,9 @@ class Elasticsearch(DatabaseBaseClass):
                    index=str(index)).query("match", **{"uuid.keyword":str(uuid)})
         for key, value in filters.items():
             s = s.filter("term", **{str(key): str(value)})
+        if 'exclude' in search_map: 
+            for key, value in search_map['exclude'].items():
+                s = s.exclude('match', **{key: value})
         _logger.debug("Building query")
         _first_bucket = str(buckets[0].split('.')[0])
         self._bucket_list.append(_first_bucket)


### PR DESCRIPTION
I've detected an indexing issue that causes lots of documents with zero norm_ops/norm_ltcy to be indexed. This issue leads into get incorrect aggregations values.

This PR applies a new exclude filter to avoid taking into account those documents.

Before:
```console
$ touchstone_compare uperf elasticsearch ripsaw -url perf-sm5039-4-5.perf.lab.eng.rdu2.redhat.com -u 52aa7bd1-2f3c-56d9-8f3c-84f663572dd5  -o csv | grep "rr, udp, 64, 1, avg"
rr, udp, 64, 1, avg(norm_ops), 52aa7bd1-2f3c-56d9-8f3c-84f663572dd5, 1869.1748633879781
rr, udp, 64, 1, avg(norm_ltcy), 52aa7bd1-2f3c-56d9-8f3c-84f663572dd5, 81.23522640707715
```

After:
```console
$ touchstone_compare uperf elasticsearch ripsaw -url perf-sm5039-4-5.perf.lab.eng.rdu2.redhat.com -u 52aa7bd1-2f3c-56d9-8f3c-84f663572dd5  -o csv | grep "rr, udp, 64, 1, avg"
rr, udp, 64, 1, avg(norm_ops), 52aa7bd1-2f3c-56d9-8f3c-84f663572dd5, 4817.732394366197
rr, udp, 64, 1, avg(norm_ltcy), 52aa7bd1-2f3c-56d9-8f3c-84f663572dd5, 209.3809356689453
```
