### PR TITLE
Granular comparison of many more metrics

### DIFF
--- a/collect_node-density.sh
+++ b/collect_node-density.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# A space-separated list of UUIDs to query
+UUIDS="88c4ac22-bc87-4557-bbab-5442ceed471d 491f27c8-f308-4bf3-a210-2e99f6ffc228 5a025027-0e4b-46c2-a88c-c32e93b120b1 75d91a2a-5208-4d49-8900-889a0a366497"
+# Which elastic to query. If all UUIDs are not from the same source, then provide a space-separated list of URLs that map to the UUIDs in order.
+ES_URL="https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443"
+OUTPUT_FILE="heavy.245ppn.v2-crun.csv"
+
+CONFIG="config/kubeburner-node-density.json"
+touchstone_compare --config $CONFIG -u $UUIDS -url $ES_URL -o csv > $OUTPUT_FILE
+
+CONFIG="config/apirequestrate_verb.json"
+touchstone_compare --config $CONFIG -u $UUIDS -url $ES_URL -o csv >> $OUTPUT_FILE
+
+CONFIG="config/etcd_distribution.json"
+touchstone_compare --config $CONFIG -u $UUIDS -url $ES_URL -o csv >> $OUTPUT_FILE
+
+CONFIG="config/apiCalls_3-buckets.json"
+touchstone_compare --config $CONFIG -u $UUIDS -url $ES_URL -o csv >> $OUTPUT_FILE
+
+CONFIG="config/node-status.json"
+touchstone_compare --config $CONFIG -u $UUIDS -url $ES_URL -o csv >> $OUTPUT_FILE
+
+CONFIG="config/serviceSyncLatency.json"
+touchstone_compare --config $CONFIG -u $UUIDS -url $ES_URL -o csv >> $OUTPUT_FILE
+
+# This config generates 4 bucket columns when all others generate 3, so it should be handled separately where it can take common formatting with other 4 bucket queries, include:
+# APIRequestRate,verb,resource
+# mutatingAPICallsLatency,verb,scope
+# readOnlyAPICallsLatency,verb,scope
+# CONFIG="config/apiCalls_4-buckets.json"
+# touchstone_compare --config $CONFIG -u $UUIDS -url $ES_URL -o csv >> $OUTPUT_FILE

--- a/config/apiCalls_3-buckets.json
+++ b/config/apiCalls_3-buckets.json
@@ -1,0 +1,102 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner*": [
+      {
+        "filter": {
+          "metricName.keyword": "schedulingThroughput"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "readOnlyAPICallsLatency"
+        },
+        "buckets": [
+          "labels.verb.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "mutatingAPICallsLatency"
+        },
+        "buckets": [
+          "labels.verb.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "readOnlyAPICallsLatency"
+        },
+        "buckets": [
+          "labels.scope.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "mutatingAPICallsLatency"
+        },
+        "buckets": [
+          "labels.scope.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      }
+
+    ]
+  }
+}

--- a/config/apiCalls_4-buckets.json
+++ b/config/apiCalls_4-buckets.json
@@ -1,0 +1,66 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner*": [
+      {
+        "filter": {
+          "metricName.keyword": "APIRequestRate"
+        },
+        "buckets": [
+          "labels.verb.keyword",
+          "labels.resource.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "readOnlyAPICallsLatency"
+        },
+        "buckets": [
+          "labels.verb.keyword",
+          "labels.scope.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "mutatingAPICallsLatency"
+        },
+        "buckets": [
+          "labels.verb.keyword",
+          "labels.scope.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/apirequestrate_verb.json
+++ b/config/apirequestrate_verb.json
@@ -1,0 +1,25 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner*": [
+      {
+        "filter": {
+          "metricName.keyword": "APIRequestRate"
+        },
+        "buckets": [
+          "labels.verb.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/etcd_distribution.json
+++ b/config/etcd_distribution.json
@@ -1,0 +1,82 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner*": [
+      {
+        "filter": {
+          "metricName.keyword": "etcdLeaderChangesRate"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "99thEtcdDiskBackendCommitDurationSeconds"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "99thEtcdDiskWalFsyncDurationSeconds"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "99thEtcdRoundTripTimeSeconds"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/kubeburner-node-density.json
+++ b/config/kubeburner-node-density.json
@@ -1,0 +1,332 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner*": [
+      {
+        "filter": {
+          "metricName.keyword": "jobSummary"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "elapsedTime": [ "max" ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "podLatencyMeasurement"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "podReadyLatency": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ],
+          "initializedLatency": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ],
+          "schedulingLatency": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "containerCPU"
+        },
+        "buckets": [
+          "labels.container.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "containerMemory"
+        },
+        "buckets": [
+          "labels.container.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "kubeletCPU"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "kubeletMemory"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "kubeletCPU"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value" : [ "avg" ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "kubeletMemory"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value" : [ "avg" ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "crioCPU"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "crioMemory"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "crioCPU"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value" : [ "avg" ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "crioMemory"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value" : [ "avg" ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeCPU-Workers"
+        },
+        "buckets": [
+          "labels.mode.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeCPU-Workers"
+        },
+        "buckets": [
+          "labels.mode.keyword"
+        ],
+        "aggregations": {
+          "value" : [ "avg" ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeMemoryUtilization-Workers"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeMemoryUtilization-Workers"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value" : [ "avg" ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeCPU-Masters"
+        },
+        "buckets": [
+          "labels.mode.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeCPU-Masters"
+        },
+        "buckets": [
+          "labels.mode.keyword"
+        ],
+        "aggregations": {
+          "value" : [ "avg" ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeMemoryAvailable-Masters"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeMemoryAvailable-Masters"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value" : [ "avg" ]
+        }
+      }
+    ]
+  }
+}

--- a/config/memory-metrics.json
+++ b/config/memory-metrics.json
@@ -1,0 +1,120 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner*": [
+      {
+        "filter": {
+          "metricName.keyword": "nodeMemoryUtilization-Workers"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeMemoryAvailable-Masters"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "kubeletMemory"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "crioMemory"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "containerMemory"
+        },
+        "buckets": [
+          "labels.container.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "containerNetworkSetupLatency"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/node-status.json
+++ b/config/node-status.json
@@ -1,0 +1,25 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner*": [
+      {
+        "filter": {
+          "metricName.keyword": "nodeStatus"
+        },
+        "buckets": [
+          "labels.condition.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,99,100
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/podLatency_distribution.json
+++ b/config/podLatency_distribution.json
@@ -1,0 +1,43 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner": [
+      {
+        "filter": {
+          "metricName.keyword": "podLatencyMeasurement"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "podReadyLatency": [
+            {
+              "percentiles": {
+                "percents": [
+                  1,25,50,75,95,99,100
+                ]
+              }
+            }
+          ],
+          "initializedLatency": [
+            {
+              "percentiles": {
+                "percents": [
+                  1,25,50,75,95,99,100
+                ]
+              }
+            }
+          ],
+          "schedulingLatency": [
+            {
+              "percentiles": {
+                "percents": [
+                  1,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/podReady_fullDistribution.json
+++ b/config/podReady_fullDistribution.json
@@ -1,0 +1,36 @@
+{
+   "elasticsearch": {
+      "ripsaw-kube-burner*": [
+      {
+        "filter": {
+          "metricName.keyword": "jobSummary"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "elapsedTime": [ "max" ]
+        }
+      },
+         {
+            "filter": {
+               "metricName.keyword": "podLatencyMeasurement"
+            },
+            "buckets": [
+               "metricName.keyword"
+            ],
+            "aggregations": {
+               "podReadyLatency": [
+                  {
+                     "percentiles": {
+                        "percents": [
+                           0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+      ]
+   }
+}

--- a/config/serviceSyncLatency.json
+++ b/config/serviceSyncLatency.json
@@ -1,0 +1,25 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner*": [
+      {
+        "filter": {
+          "metricName.keyword": "serviceSyncLatency"
+        },
+        "buckets": [
+          "metricName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            {
+              "percentiles": {
+                "percents": [
+                  0,1,5,25,50,75,95,99,100
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Description
Adding several configs that I have used for several analyses so far.
Including:
* an abridged, symmetric distribution with most metrics (0,1,5,25,50,75,95,99,100 percentiles).
* a full 1-percentile distribution of podReady latencies.
* a helper script example