### PR TITLE
Remove return that prevents multiple queries from a single config

### DIFF
--- a/src/touchstone/compare.py
+++ b/src/touchstone/compare.py
@@ -229,7 +229,6 @@ def main(args):
                     output_file.write(json.dumps(timeseries_result, indent=4))
                 if args.output == "yaml":
                     output_file.write(yaml.dump(timeseries_result, allow_unicode=True))
-                return
             if index_json and not args.tolerancy_rules:
                 row_list = []
                 if args.output == "csv":


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If I create touchstone config with multiple "timeseries" queries (i.e. "compute_map") under a single index, this return statement only runs the first timeseries, then aborts from the for loop.

## Related Tickets & Documents

None.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Run against search dev instance.

Here is an example config:
```
{
  "elasticsearch": {
    "ripsaw-kube-burner": [
      {
        "filter": {
          "metricName.keyword": "cgroupCPUSeconds-namespaces"
        },
        "timeseries": true
      },
      {
        "filter": {
          "metricName.keyword": "cgroupCPUSeconds-namespaces-start"
        },
        "timeseries": true
      }
    ]
  }
}
```

Here is a script to run it:
```
$ cat collect_seconds.sh 
#!/bin/bash

UUIDS="2b7c7289-9a8c-404d-a667-59bb213e63a7"
ES_URL="https://search-perfscale-dev-...amazonaws.com:443"

OUTPUT_FILE="cpu_seconds.json"
CONFIG="config/cpu_seconds.json"
touchstone_compare -vv --config $CONFIG -u $UUIDS -url $ES_URL -o json > $OUTPUT_FILE
```